### PR TITLE
examples: fix: bidirectional message timeout

### DIFF
--- a/examples/bidirectional-calls/client.js
+++ b/examples/bidirectional-calls/client.js
@@ -17,16 +17,20 @@ async function main() {
     const client = new MoleClient({
         requestTimeout: 1000,
         transport: new TransportClientWS({
+            wsBuilder: () => ws
+        })
+    });
+
+    // Server
+    const server = new MoleServer({
+        transports: [new TransportServerWS({
             wsBuilder: () => {
                 // create new connection and share it with server
                 ws = new WebSocket(`ws://localhost:${WSS_PORT}`);
                 return ws;
             }
-        })
+        })]
     });
-
-    // Server
-    const server = new MoleServer({ transports: [new TransportServerWS({ wsBuilder: () => ws })] });
     server.expose({ substract, divide });
     await server.run();
 

--- a/examples/bidirectional-calls/server.js
+++ b/examples/bidirectional-calls/server.js
@@ -18,7 +18,14 @@ async function main() {
 
     wss.on('connection', async ws => {
         try {
-            server.registerTransport(new TransportServerWS({ wsBuilder: () => ws }));
+            let transport = new TransportServerWS({ wsBuilder: () => ws });
+
+            // terminate the transport on connection close
+            // if not, server-side wsBuilder(s) get called
+            // periodically after connection is closed
+            ws.on("close", () => transport.terminate());
+
+            server.registerTransport(transport);
 
             const client = new MoleClient({
                 requestTimeout: 1000,


### PR DESCRIPTION
`wsBuilders` are called asynchronously so server's one returned `ws` that was `null`.